### PR TITLE
Update parser to handle correctly `order-only-prerequisites`

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -129,7 +129,7 @@ func (p *Parser) parseVertices(g graph.Graph[string], line string) error {
 
 		for _, v := range strings.Split(toItems, " ") {
 			v = strings.TrimSpace(v)
-			if v == "" {
+			if v == "" || v == "|" {
 				continue
 			}
 			g.AddVertex(v)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -98,6 +98,9 @@ func TestParseVerticesLine(t *testing.T) {
 	testCases := []testCase{
 		{line: "foo:", wantErr: nil, wantVs: 1, wantEs: 0},
 		{line: "foo: bar", wantErr: nil, wantVs: 2, wantEs: 1},
+		{line: "foo: | bar", wantErr: nil, wantVs: 2, wantEs: 1},
+		{line: "foo: bar | baz", wantErr: nil, wantVs: 3, wantEs: 2},
+		{line: "foo: baz qux", wantErr: nil, wantVs: 3, wantEs: 2},
 		{line: "foo bar: baz qux", wantErr: nil, wantVs: 4, wantEs: 4},
 		{line: "foo", wantErr: ErrInvalidTarget},
 	}


### PR DESCRIPTION
Without this commit, a node without name is generated in `graph.svg` when a `|` (aka pipe) is in prerequisites.
See https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html for more informations about order-only prerequisites.